### PR TITLE
Fix build errors

### DIFF
--- a/web-ui/pages/index.vue
+++ b/web-ui/pages/index.vue
@@ -28,7 +28,7 @@ export default {
 
       const doc = iframe.contentDocument;
       doc.open();
-      doc.write(`<script>${this.code}</script` + ">");
+      doc.write(unescape("%3Cscript%3E" + this.code + "%3C/script%3E"));
       doc.close();
     },
   },


### PR DESCRIPTION
Fix build errors by utilizing escape/unescape to work around document.write's reluctance to work with a <script> tag.

Resolves #16